### PR TITLE
Correct schedule in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ certificates:
 - elasticsearch
 curator:
   install: true
-  schedule: "0 5 2 * * *"
+  schedule: "0 5 * * *"
 ```
 
 


### PR DESCRIPTION
0 5 2 * * * is not a valid crontab schedule value
I set it to "0 5 * * *" as example for running it on a daily base at 5 o'clock
